### PR TITLE
Improve node editing controls

### DIFF
--- a/docs/architecture/structure-20250702-after.mmd
+++ b/docs/architecture/structure-20250702-after.mmd
@@ -1,0 +1,17 @@
+```mermaid
+graph TD
+    Root((jsonic-editor))
+    Root --> src
+    Root --> docs
+    Root --> packageJson[package.json]
+    Root --> tsconfig[tsconfig.json]
+    Root --> vite[vite.config.ts]
+    src --> components
+    src --> core
+    src --> hooks
+    src --> mocks
+    src --> state
+    src --> styles
+    src --> types
+    src --> utils
+```

--- a/docs/architecture/structure-20250702-before.mmd
+++ b/docs/architecture/structure-20250702-before.mmd
@@ -1,0 +1,17 @@
+```mermaid
+graph TD
+    Root((jsonic-editor))
+    Root --> src
+    Root --> docs
+    Root --> packageJson[package.json]
+    Root --> tsconfig[tsconfig.json]
+    Root --> vite[vite.config.ts]
+    src --> components
+    src --> core
+    src --> hooks
+    src --> mocks
+    src --> state
+    src --> styles
+    src --> types
+    src --> utils
+```

--- a/docs/architecture/structure-20250703-after.mmd
+++ b/docs/architecture/structure-20250703-after.mmd
@@ -1,0 +1,17 @@
+```mermaid
+graph TD
+    Root((jsonic-editor))
+    Root --> src
+    Root --> docs
+    Root --> packageJson[package.json]
+    Root --> tsconfig[tsconfig.json]
+    Root --> vite[vite.config.ts]
+    src --> components
+    src --> core
+    src --> hooks
+    src --> mocks
+    src --> state
+    src --> styles
+    src --> types
+    src --> utils
+```

--- a/docs/architecture/structure-20250703-before.mmd
+++ b/docs/architecture/structure-20250703-before.mmd
@@ -1,0 +1,17 @@
+```mermaid
+graph TD
+    Root((jsonic-editor))
+    Root --> src
+    Root --> docs
+    Root --> packageJson[package.json]
+    Root --> tsconfig[tsconfig.json]
+    Root --> vite[vite.config.ts]
+    src --> components
+    src --> core
+    src --> hooks
+    src --> mocks
+    src --> state
+    src --> styles
+    src --> types
+    src --> utils
+```

--- a/docs/checklists/20250702-session.md
+++ b/docs/checklists/20250702-session.md
@@ -1,0 +1,8 @@
+Session checklist for 2025-07-02
+
+- [ ] Document current architecture in `docs/architecture/structure-20250702-before.mmd`
+- [ ] Improve node editing UX with textarea for long strings
+- [ ] Use checkbox controls for boolean values
+- [ ] Allow inserting new nodes via intuitive controls
+- [ ] Document updated architecture in `docs/architecture/structure-20250702-after.mmd`
+- [ ] Ensure `npm test` runs

--- a/docs/checklists/20250703-session.md
+++ b/docs/checklists/20250703-session.md
@@ -1,0 +1,8 @@
+Session checklist for 2025-07-03
+
+- [ ] Document current architecture in `docs/architecture/structure-20250703-before.mmd`
+- [ ] Allow single-click editing for node values
+- [ ] Expand textarea for large strings and left-justify content
+- [ ] Add multi-selection with SHIFT/CTRL and pass selected ids for drag/drop
+- [ ] Document updated architecture in `docs/architecture/structure-20250703-after.mmd`
+- [ ] Ensure `npm test` runs

--- a/src/components/nodes/JsonNode.module.css
+++ b/src/components/nodes/JsonNode.module.css
@@ -17,7 +17,7 @@
   cursor: pointer;
   transition: background-color 0.2s, opacity 0.2s;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   min-height: 28px;
   user-select: none;
 }
@@ -86,4 +86,27 @@
   margin-left: 16px;
   border-left: 1px dashed #e0e0e0;
   padding-left: 8px;
+}
+
+.addButton {
+  margin-left: 4px;
+  font-size: 12px;
+  padding: 0 4px;
+}
+
+.addSelect {
+  margin-left: 4px;
+  font-size: 12px;
+}
+
+.nodeContent {
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+}
+
+.editField {
+  width: 100%;
+  font-family: inherit;
+  font-size: 14px;
 }

--- a/src/core/parser/json-parser.ts
+++ b/src/core/parser/json-parser.ts
@@ -1,4 +1,4 @@
-import { JsonNode } from '../../types/core';
+import { JsonNode, NodeType } from '../../types/core';
 import { v4 as uuidv4 } from 'uuid';
 
 export class JsonParser {
@@ -22,19 +22,19 @@ export class JsonParser {
 
   private convert(data: any, parent?: string): JsonNode[] {
     if (Array.isArray(data)) {
-      return data.map(item => this.createNode('array', undefined, undefined, this.convert(item as any, parent)));
+      return data.map(item => this.createNode(NodeType.ARRAY, undefined, undefined, this.convert(item as any, parent)));
     }
     if (typeof data === 'object' && data !== null) {
       return Object.entries(data).map(([key, value]) => {
         const nodeType = this.getType(value);
-        const children = nodeType === 'object' || nodeType === 'array' ? this.convert(value as any, key) : undefined;
+        const children = nodeType === NodeType.OBJECT || nodeType === NodeType.ARRAY ? this.convert(value as any, key) : undefined;
         return this.createNode(nodeType, key, value, children, parent);
       });
     }
     return [this.createNode(this.getType(data), undefined, data, undefined, parent)];
   }
 
-  private createNode(type: JsonNode['type'], key?: string, value?: any, children?: JsonNode[], parent?: string): JsonNode {
+  private createNode(type: NodeType, key?: string, value?: any, children?: JsonNode[], parent?: string): JsonNode {
     return {
       id: uuidv4(),
       type,
@@ -47,9 +47,20 @@ export class JsonParser {
     };
   }
 
-  private getType(value: any): JsonNode['type'] {
-    if (Array.isArray(value)) return 'array';
-    if (value === null) return 'null';
-    return typeof value as JsonNode['type'];
+  private getType(value: any): NodeType {
+    if (Array.isArray(value)) return NodeType.ARRAY;
+    if (value === null) return NodeType.NULL;
+    switch (typeof value) {
+      case 'object':
+        return NodeType.OBJECT;
+      case 'string':
+        return NodeType.STRING;
+      case 'number':
+        return NodeType.NUMBER;
+      case 'boolean':
+        return NodeType.BOOLEAN;
+      default:
+        return NodeType.NULL;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add session checklist and architecture snapshot for 2025-07-03
- update JsonNode module styles for left-justified content
- enable single-click editing with dynamic textarea sizing
- support multi-selection in demo and recursive nodes

## Testing
- `npm test` *(fails: vitest not found)*
- `npx tsc -p tsconfig.json` *(fails to find React type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686479a0bb588323be0c8e1fc5eea41f