### PR TITLE
Implement insert and drag/drop reordering with multi-format support

### DIFF
--- a/docs/architecture/structure-20250704-after.mmd
+++ b/docs/architecture/structure-20250704-after.mmd
@@ -1,0 +1,19 @@
+```mermaid
+graph TD
+    Root((jsonic-editor))
+    Root --> src
+    Root --> docs
+    Root --> packageJson[package.json]
+    Root --> tsconfig[tsconfig.json]
+    Root --> vite[vite.config.ts]
+    src --> components
+    src --> core
+    src --> hooks
+    src --> mocks
+    src --> state
+    src --> styles
+    src --> types
+    src --> utils
+    core --> parser
+    components --> nodes
+```

--- a/docs/architecture/structure-20250704-before.mmd
+++ b/docs/architecture/structure-20250704-before.mmd
@@ -1,0 +1,17 @@
+```mermaid
+graph TD
+    Root((jsonic-editor))
+    Root --> src
+    Root --> docs
+    Root --> packageJson[package.json]
+    Root --> tsconfig[tsconfig.json]
+    Root --> vite[vite.config.ts]
+    src --> components
+    src --> core
+    src --> hooks
+    src --> mocks
+    src --> state
+    src --> styles
+    src --> types
+    src --> utils
+```

--- a/docs/checklists/20250704-session.md
+++ b/docs/checklists/20250704-session.md
@@ -1,0 +1,8 @@
+Session checklist for 2025-07-04
+
+- [ ] Document current architecture in `docs/architecture/structure-20250704-before.mmd`
+- [ ] Allow inserting nodes at arbitrary positions
+- [ ] Enable drag-and-drop reordering anywhere in the file
+- [ ] Support parsing and exporting YAML, TOML, and INI formats
+- [ ] Document updated architecture in `docs/architecture/structure-20250704-after.mmd`
+- [ ] Ensure `npm test` runs

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,17 +8,21 @@
       "name": "jsonic-editor",
       "version": "0.1.0",
       "dependencies": {
+        "@iarna/toml": "^2.2.5",
         "@types/react-dnd": "^2.0.36",
         "@types/react-dnd-html5-backend": "^3.0.2",
         "classnames": "^2.3.0",
+        "ini": "^5.0.0",
         "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-dnd": "^16.0.1",
         "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "^18.2.0",
+        "toml": "^3.0.0",
         "typescript": "^5.0.0",
         "uuid": "^9.0.0",
-        "vite": "^4.4.0"
+        "vite": "^4.4.0",
+        "yaml": "^2.8.0"
       },
       "devDependencies": {
         "@types/lodash": "^4.17.0",
@@ -693,6 +697,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@iarna/toml": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
+      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
+      "license": "ISC"
     },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
@@ -1688,6 +1698,15 @@
         "node": ">=16.17.0"
       }
     },
+    "node_modules/ini": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-5.0.0.tgz",
+      "integrity": "sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -2283,6 +2302,12 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
     },
     "node_modules/type-detect": {
       "version": "4.1.0",
@@ -3574,6 +3599,18 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -11,17 +11,21 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@iarna/toml": "^2.2.5",
     "@types/react-dnd": "^2.0.36",
     "@types/react-dnd-html5-backend": "^3.0.2",
     "classnames": "^2.3.0",
+    "ini": "^5.0.0",
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
     "react-dom": "^18.2.0",
+    "toml": "^3.0.0",
     "typescript": "^5.0.0",
     "uuid": "^9.0.0",
-    "vite": "^4.4.0"
+    "vite": "^4.4.0",
+    "yaml": "^2.8.0"
   },
   "devDependencies": {
     "@types/lodash": "^4.17.0",

--- a/src/components/demos/JsonNodeDemo.tsx
+++ b/src/components/demos/JsonNodeDemo.tsx
@@ -89,9 +89,25 @@ const JsonNodeDemo: React.FC = () => {
     console.log('Context menu for node:', node);
   };
 
-  const handleDrop = (draggedId: string, targetId: string) => {
-    console.log(`Dropped node ${draggedId} on ${targetId}`);
-    // Implement node reordering logic here
+  const handleDrop = (draggedId: string, parentId: string, index: number) => {
+    const moveNode = (node: JsonNode): JsonNode => {
+      if (!node.children) return node;
+      const draggedIdx = node.children.findIndex(c => c.id === draggedId);
+      if (draggedIdx !== -1) {
+        const [dragged] = node.children.splice(draggedIdx, 1);
+        if (node.id === parentId) {
+          node.children.splice(index, 0, dragged);
+        } else {
+          node.children = node.children.map(moveNode);
+          if (node.id === parentId) {
+            node.children.splice(index, 0, dragged);
+          }
+        }
+        return { ...node };
+      }
+      return { ...node, children: node.children.map(moveNode) };
+    };
+    setNodes(prev => ({ ...moveNode(prev) }));
   };
 
   const handleToggleExpand = (nodeId: string) => {
@@ -101,11 +117,12 @@ const JsonNodeDemo: React.FC = () => {
     }));
   };
 
-  const handleAddChild = (parentId: string, type: NodeType) => {
+  const handleAddChild = (parentId: string, type: NodeType, index = 0) => {
     const newNode = createNode(type);
     const addTo = (node: JsonNode): JsonNode => {
       if (node.id === parentId) {
-        const children = node.children ? [...node.children, newNode] : [newNode];
+        const children = node.children ? [...node.children] : [];
+        children.splice(index, 0, newNode);
         return { ...node, children };
       }
       return {
@@ -119,7 +136,7 @@ const JsonNodeDemo: React.FC = () => {
 
   const handleOpenFile = async () => {
     try {
-      const parsed = await fileHandler.openJson();
+      const { nodes: parsed } = await fileHandler.openDocument();
       const root: JsonNode = {
         id: 'root',
         type: NodeType.OBJECT,

--- a/src/components/nodes/JsonNode.module.css
+++ b/src/components/nodes/JsonNode.module.css
@@ -88,6 +88,21 @@
   padding-left: 8px;
 }
 
+.insertRow {
+  display: flex;
+  align-items: center;
+}
+
+.dropZone {
+  flex-grow: 1;
+  height: 4px;
+  margin: 2px 0;
+}
+
+.dropZoneActive {
+  background-color: #90caf9;
+}
+
 .addButton {
   margin-left: 4px;
   font-size: 12px;

--- a/src/components/nodes/drop-zone.tsx
+++ b/src/components/nodes/drop-zone.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { useDrop } from 'react-dnd';
+import styles from './JsonNode.module.css';
+
+interface DragItem {
+  id: string;
+  type: string;
+}
+
+interface Props {
+  parentId: string;
+  index: number;
+  onDrop: (draggedId: string, parentId: string, index: number) => void;
+}
+
+export function DropZone({ parentId, index, onDrop }: Props) {
+  const [{ isOver }, drop] = useDrop<DragItem, void, { isOver: boolean}>({
+    accept: 'NODE',
+    drop: (item) => onDrop(item.id, parentId, index),
+    collect: monitor => ({ isOver: monitor.isOver() })
+  });
+
+  return (
+    <div ref={drop} className={`${styles.dropZone} ${isOver ? styles.dropZoneActive : ''}`} />
+  );
+}

--- a/src/core/parser/generic-parser.ts
+++ b/src/core/parser/generic-parser.ts
@@ -1,0 +1,40 @@
+import { JsonNode } from '../../types/core';
+import { JsonParser } from './json-parser';
+import YAML from 'yaml';
+import toml from '@iarna/toml';
+import { parse as parseIni, stringify as stringifyIni } from 'ini';
+
+export type SupportedFormat = 'json' | 'yaml' | 'toml' | 'ini';
+
+export class GenericParser {
+  private json = new JsonParser();
+
+  parse(content: string, format: SupportedFormat): JsonNode[] {
+    switch (format) {
+      case 'yaml':
+        return this.json.parse(JSON.stringify(YAML.parse(content)));
+      case 'toml':
+        return this.json.parse(JSON.stringify(toml.parse(content)));
+      case 'ini':
+        return this.json.parse(JSON.stringify(parseIni(content)));
+      case 'json':
+      default:
+        return this.json.parse(content);
+    }
+  }
+
+  serialize(nodes: JsonNode[], format: SupportedFormat): string {
+    const obj = JSON.parse(this.json.serialize(nodes));
+    switch (format) {
+      case 'yaml':
+        return YAML.stringify(obj);
+      case 'toml':
+        return toml.stringify(obj as any);
+      case 'ini':
+        return stringifyIni(obj as any);
+      case 'json':
+      default:
+        return JSON.stringify(obj, null, 2);
+    }
+  }
+}

--- a/src/state/stores/document-store.ts
+++ b/src/state/stores/document-store.ts
@@ -26,13 +26,33 @@ export class DocumentStore {
     if (node) Object.assign(node, updates);
   }
 
-  addNode(parentId: string, node: JsonNode): void {
+  addNode(parentId: string, node: JsonNode, index?: number): void {
     const parent = this.getNode(parentId);
     if (parent) {
       parent.children = parent.children || [];
-      parent.children.push(node);
+      if (index === undefined || index >= parent.children.length) {
+        parent.children.push(node);
+      } else {
+        parent.children.splice(index, 0, node);
+      }
       node.parent = parentId;
     }
+  }
+
+  moveNode(nodeId: string, newParentId: string, index: number): void {
+    const node = this.getNode(nodeId);
+    const oldParent = node ? this.getParent(nodeId) : null;
+    const newParent = this.getNode(newParentId);
+    if (!node || !newParent) return;
+    if (oldParent && oldParent.children) {
+      oldParent.children = oldParent.children.filter(c => c.id !== nodeId);
+    } else {
+      this.nodes = this.nodes.filter(n => n.id !== nodeId);
+    }
+    newParent.children = newParent.children || [];
+    if (index > newParent.children.length) index = newParent.children.length;
+    newParent.children.splice(index, 0, node);
+    node.parent = newParentId;
   }
 
   deleteNode(nodeId: string): void {


### PR DESCRIPTION
## Summary
- allow adding nodes at any position with new drop zones and add buttons
- support dragging nodes to reorder anywhere in the tree
- add GenericParser for JSON, YAML, TOML and INI
- update FileHandler and DocumentStore for new capabilities
- document architecture before/after and session checklist

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ad64c910832389bd251fce298486