### PR TITLE
Enhance graph interactions and editing flow

### DIFF
--- a/docs/ARCHITECTURE/architecture-20251231-021822.md
+++ b/docs/ARCHITECTURE/architecture-20251231-021822.md
@@ -1,0 +1,96 @@
+# Architecture Plan (2025-12-31 02:18:22 UTC)
+
+## Repository Snapshot (Abstracted AST Overview)
+- **App (`jsonic/src/App.tsx`)**
+  - Maintains React state: `currentView`, `graph: JsonGraph`, `textContent`, `currentFile`, `status`.
+  - Uses toolbar, graph, text editor, and status bar components.
+  - Sync utilities: `jsonToGraph`, `graphToJson` from `utils/jsonParser`.
+- **GraphView (`jsonic/src/components/GraphView.tsx`)**
+  - Functional component rendering Cytoscape graph from `JsonGraph` nodes/edges.
+  - Props: `graph`, `onNodeSelect`, `onNodeEdit`, `onNodeCreate`, `onNodeDelete`, `onNodeMove`.
+  - Initializes Cytoscape layout (`breadthfirst`) and registers simple tap handler to select nodes.
+- **Types (`jsonic/src/types/jsonTypes.ts`)**
+  - `JsonNode` shape with id, type, optional key/value/children/parent/position/comments.
+  - `JsonGraph` containing nodes, edges (parent/sibling), metadata.
+- **JSON Parser Utils (`jsonic/src/utils/jsonParser.ts`)**
+  - Converters between JSON value and `JsonGraph` (bidirectional).
+  - Helpers: `findNode`, `addChildNode`, `updateNode` (no delete/move helpers yet).
+- **UI Components**
+  - Toolbar, TextEditor, StatusBar are present for layout and file operations.
+
+## Proposed Solution (Eventful Graph Editing & Navigation)
+1. **GraphView Interaction Layer**
+   - Expose rich Cytoscape event hooks:
+     - Node **double-tap/double-click** → trigger `onNodeEdit` with `{ id, key, value, type, position }` payload.
+     - **Context menu** on node and background → show native `contextmenu` with options (edit, create child, delete, move) via callback payloads.
+     - **Drag-and-drop** node moves → on grab/free events capture start/end positions and parent relationship changes, fire `onNodeMove`.
+     - **Zoom/pan** events → provide `onViewportChange`-like payload to maintain stable layout (tracking `position`, `zoom`, `pan`).
+   - Maintain selection highlighting and keyboard focus mapping (Tab/Shift+Tab cycling nodes, Ctrl+Arrow for parent/child/sibling travel).
+2. **App State Mutation**
+   - Implement callbacks to mutate `graph` using utility helpers:
+     - Add utility helpers for delete, move, connect edges (extend `jsonParser.ts`).
+     - Keep node `position` to preserve layout during edits.
+     - Re-sync text view after mutations via `graphToJson`.
+   - Confirm deletion actions before mutating state.
+3. **Context Menus & Keyboard Shortcuts**
+   - Provide at least one actionable context menu (e.g., on node: Edit, Add Child, Delete with confirmation, Center View).
+   - Keyboard navigation: Tab/Shift+Tab to iterate nodes; Ctrl+Arrow to navigate relationally.
+
+## Diagrams
+
+### Component Interaction (Mermaid UML Class Diagram)
+```mermaid
+classDiagram
+  class App {
+    state graph: JsonGraph
+    state currentView
+    +handleOpenFile()
+    +handleSaveFile()
+    +onGraphNodeEdit()
+    +onGraphNodeCreate()
+    +onGraphNodeDelete()
+    +onGraphNodeMove()
+  }
+  class GraphView {
+    +render Cytoscape graph
+    +emit node selection/edit/create/delete/move events
+    +handle keyboard shortcuts
+  }
+  class jsonParser {
+    +jsonToGraph()
+    +graphToJson()
+    +addChildNode()
+    +updateNode()
+    +removeNode()
+    +moveNode()
+  }
+  App --> GraphView : props
+  App --> jsonParser : utilities
+  GraphView --> App : event callbacks
+```
+
+### State & Event Flow (Mermaid Sequence)
+```mermaid
+sequenceDiagram
+  participant User
+  participant GraphView
+  participant App
+  participant jsonParser
+
+  User->>GraphView: Double-click node
+  GraphView-->>App: onNodeEdit({ id, key, value, type, position })
+  App->>jsonParser: updateNode(graph, id, updates)
+  jsonParser-->>App: updated graph
+  App-->>GraphView: setGraph(updated)
+  App-->>TextEditor: setTextContent(graphToJson(updated))
+
+  User->>GraphView: Context menu -> Delete
+  GraphView-->>App: onNodeDelete({ id, parentId })
+  App->>jsonParser: removeNode(graph, id)
+  jsonParser-->>App: updated graph
+```
+
+## Notes
+- External hybrid knowledge graph integrations (Neo4j/Qdrant/Postgres) are **not performed** because external network/stateful writes are disallowed in this environment; architecture kept local.
+- The plan prioritizes stable layout by persisting Cytoscape positions and minimizing full relayouts.
+```

--- a/docs/ARCHITECTURE/architecture-20260105-212546.md
+++ b/docs/ARCHITECTURE/architecture-20260105-212546.md
@@ -1,0 +1,32 @@
+# Architecture Plan (2026-01-05 21:25:46 UTC)
+
+## Repository Snapshot (Abstracted AST Overview)
+- **App (`jsonic/src/App.tsx`)**
+  - State: `currentView`, `graph: JsonGraph`, `textContent`, `currentFile`, `status`, `selectedNodeId`.
+  - Graph callbacks: handles node select/edit/create/delete/move and updates text via `graphToJson`.
+  - Utilities from `utils/jsonParser`: `addChildNode`, `findNode`, `moveNode`, `removeNode`, `updateNode`, `graphToJson`, `jsonToGraph`.
+- **GraphView (`jsonic/src/components/GraphView.tsx`)**
+  - Uses Cytoscape; renders nodes/edges derived from `JsonGraph`.
+  - Emits structured callbacks for select/edit/create/delete/move, keyboard navigation, context menu, drag reparenting, viewport/position updates.
+  - Edges currently omit `type` data in element payloads (inline comment notes traversal relies on `edge[type="parent"]`).
+- **jsonParser utilities (`jsonic/src/utils/jsonParser.ts`)**
+  - Helpers for conversion plus `addChildNode`, `addEdge`, `removeNode`, `moveNode`, `updateNode`, `findNode`.
+  - `moveNode` lacks guard against assigning a node under its own descendant (could create cycle).
+- **Docs**
+  - Architecture and checklist files stored under `docs/ARCHITECTURE` and `docs/CHECKLISTS`.
+
+## Required Changes (per review feedback)
+1. **Cytoscape edge typing**
+   - When building edge elements in `GraphView.tsx`, include `type` in `data` so selectors like `edge[type="parent"]` work for navigation.
+2. **Guard reparenting cycles**
+   - In `moveNode` (`jsonParser.ts`), prevent moving a node under itself or any descendant. If attempted, skip mutation.
+3. **Safety updates**
+   - Ensure resulting graph remains connected and positions preserved where provided.
+
+## Approach
+- Update `GraphView` edge mapping to attach `type` field from `JsonGraph.edges`.
+- Enhance `moveNode` with descendant check using DFS from candidate parent to ensure `nodeId` not reachable.
+- Run build to validate TypeScript.
+
+## Notes
+- External hybrid knowledge graph persistence endpoints provided but not used here due to environment constraints; architecture recorded locally.

--- a/docs/CHECKLISTS/checklist-graph-enhancements-20251231-021822.md
+++ b/docs/CHECKLISTS/checklist-graph-enhancements-20251231-021822.md
@@ -1,0 +1,24 @@
+# Checklist — Graph Interaction Enhancements (2025-12-31 02:18:22 UTC)
+
+Status legend: [ ] not started, [/] in progress, [x] done (awaiting test), ✅ tested & complete.
+
+- [x] Capture current architecture and event-flow plan in `docs/ARCHITECTURE/architecture-20251231-021822.md`.
+- [x] Extend `jsonic/src/utils/jsonParser.ts` with graph mutation helpers:
+  - `removeNode(graph, nodeId)` to delete node and descendant edges, reassign children as needed.
+  - `moveNode(graph, nodeId, newParentId)` to update parent reference, children arrays, and edge endpoints while preserving positions.
+  - `addEdge(graph, sourceId, targetId, type)` utility for future-proofing (parent edges only for now).
+- [x] Upgrade `jsonic/src/components/GraphView.tsx`:
+  - Preserve Cytoscape instance with stable layout; update elements without auto re-layout unless positions missing.
+  - Register event listeners: double-click for edit, contextmenu for node actions, drag/position change for move, tap background deselect, zoom/pan tracking.
+  - Implement keyboard navigation: Tab/Shift+Tab cycles nodes, Ctrl+Arrow traverses parent/child/sibling (based on edges/children data), Enter triggers edit.
+  - Expose callbacks with structured payloads `{ id, key, type, value, position, parentId }` etc.
+  - Provide at least one context menu (node) with actions: Edit, Add Child, Delete (with confirm), Center/Focus.
+- [x] Implement App-level callbacks in `jsonic/src/App.tsx` using utilities:
+  - `handleNodeCreate`, `handleNodeEdit`, `handleNodeDelete`, `handleNodeMove`, `handleNodeSelect`.
+  - Maintain layout stability by preserving/propagating `position` on nodes; avoid resetting Cytoscape layout unnecessarily.
+  - Synchronize `textContent` after graph mutation via `graphToJson`.
+  - Confirm deletes with `window.confirm` guard.
+- [x] Wire callbacks to both graph view instances (graph and split view) and status messaging where applicable.
+- [x] Ensure keyboard shortcuts and context menus do not conflict with existing toolbar shortcuts; document keymap hints in code comments if helpful.
+- [✅] Smoke test UI logic (unit tests unavailable): run `npm test`/`npm run lint` if configured, otherwise basic type check/build command; note outcomes.
+- [✅] Update checklist statuses post-implementation and testing.

--- a/docs/CHECKLISTS/checklist-graph-review-fixes-20260105-212546.md
+++ b/docs/CHECKLISTS/checklist-graph-review-fixes-20260105-212546.md
@@ -1,0 +1,9 @@
+# Checklist — Graph review fixes (2026-01-05 21:25:46 UTC)
+
+Status legend: [ ] not started, [/] in progress, [x] done (awaiting test), ✅ tested & complete.
+
+- [x] Record architecture/plan in `docs/ARCHITECTURE/architecture-20260105-212546.md`.
+- [x] Add edge `type` metadata to Cytoscape elements in `jsonic/src/components/GraphView.tsx` for traversal selectors.
+- [x] Guard against moving a node under itself/descendants in `jsonic/src/utils/jsonParser.ts` `moveNode` helper.
+- [✅] Run `npm run build` (or available checks) and capture results.
+- [✅] Update checklist statuses after implementation/testing.

--- a/jsonic/src/components/GraphView.tsx
+++ b/jsonic/src/components/GraphView.tsx
@@ -74,7 +74,8 @@ const GraphView: React.FC<GraphViewProps> = ({
       data: { 
         id: edge.id,
         source: edge.source, 
-        target: edge.target 
+        target: edge.target,
+        type: edge.type
       }
     }));
 

--- a/jsonic/src/components/GraphView.tsx
+++ b/jsonic/src/components/GraphView.tsx
@@ -1,14 +1,40 @@
-import React, { useEffect, useRef } from 'react';
-import cytoscape from 'cytoscape';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import cytoscape, { ElementDefinition } from 'cytoscape';
 import { JsonGraph } from '../types/jsonTypes';
 
 interface GraphViewProps {
   graph: JsonGraph;
-  onNodeSelect: (nodeId: string) => void;
-  onNodeEdit: (nodeId: string, value: any) => void;
-  onNodeCreate: (parentId: string, node: any) => void;
-  onNodeDelete: (nodeId: string) => void;
-  onNodeMove: (nodeId: string, newParentId: string) => void;
+  onNodeSelect: (payload: {
+    id: string;
+    key?: string;
+    type: string;
+    value?: any;
+    position?: { x: number; y: number };
+    parentId?: string;
+  }) => void;
+  onNodeEdit: (payload: {
+    id: string;
+    key?: string;
+    type: string;
+    value?: any;
+    position?: { x: number; y: number };
+    parentId?: string;
+  }) => void;
+  onNodeCreate: (payload: {
+    parentId: string;
+    position?: { x: number; y: number };
+  }) => void;
+  onNodeDelete: (payload: {
+    id: string;
+    parentId?: string;
+  }) => void;
+  onNodeMove: (payload: {
+    id: string;
+    newParentId: string;
+    position?: { x: number; y: number };
+  }) => void;
+  onViewportChange?: (payload: { zoom: number; pan: { x: number; y: number } }) => void;
+  onPositionsUpdate?: (positions: Record<string, { x: number; y: number }>) => void;
 }
 
 const GraphView: React.FC<GraphViewProps> = ({
@@ -17,23 +43,34 @@ const GraphView: React.FC<GraphViewProps> = ({
   onNodeEdit,
   onNodeCreate,
   onNodeDelete,
-  onNodeMove
+  onNodeMove,
+  onViewportChange,
+  onPositionsUpdate
 }) => {
   const cyRef = useRef<cytoscape.Core | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const [contextMenu, setContextMenu] = useState<{
+    x: number;
+    y: number;
+    targetId: string | null;
+    parentId?: string;
+  } | null>(null);
 
   // Convert our JSON graph to Cytoscape elements
-  const convertToCytoscapeElements = () => {
-    const nodes = graph.nodes.map(node => ({
+  const convertToCytoscapeElements = useMemo(() => {
+    const nodes: ElementDefinition[] = graph.nodes.map(node => ({
       data: { 
         id: node.id, 
         label: node.key || (node.value !== undefined ? String(node.value) : node.type),
-        type: node.type
+        type: node.type,
+        key: node.key,
+        value: node.value,
+        parentId: node.parent
       },
       position: node.position
     }));
 
-    const edges = graph.edges.map(edge => ({
+    const edges: ElementDefinition[] = graph.edges.map(edge => ({
       data: { 
         id: edge.id,
         source: edge.source, 
@@ -42,14 +79,165 @@ const GraphView: React.FC<GraphViewProps> = ({
     }));
 
     return [...nodes, ...edges];
+  }, [graph.edges, graph.nodes]);
+
+  const layoutOptions = useMemo(
+    () => ({
+      name: 'breadthfirst',
+      directed: true,
+      padding: 10,
+      spacingFactor: 1.5,
+      avoidOverlap: true,
+      nodeDimensionsIncludeLabels: true
+    }),
+    []
+  );
+
+  const syncPositionsToParent = () => {
+    if (!cyRef.current || !onPositionsUpdate) return;
+    const positions: Record<string, { x: number; y: number }> = {};
+    cyRef.current.nodes().forEach(node => {
+      positions[node.id()] = node.position();
+    });
+    onPositionsUpdate(positions);
   };
+
+  const closeContextMenu = () => setContextMenu(null);
+
+  const handleContextAction = (action: 'edit' | 'add' | 'delete' | 'center') => {
+    if (!contextMenu || !cyRef.current) return;
+
+    const target = cyRef.current.getElementById(contextMenu.targetId ?? '');
+    const data = target.data();
+    const payload = {
+      id: target.id(),
+      key: data.key,
+      type: data.type,
+      value: data.value,
+      position: target.position(),
+      parentId: data.parentId as string | undefined
+    };
+
+    switch (action) {
+      case 'edit':
+        onNodeEdit(payload);
+        break;
+      case 'add':
+        onNodeCreate({ parentId: target.id(), position: target.position() });
+        break;
+      case 'delete': {
+        const shouldDelete = window.confirm('Delete this node and its descendants?');
+        if (shouldDelete) {
+          onNodeDelete({ id: target.id(), parentId: data.parentId as string | undefined });
+        }
+        break;
+      }
+      case 'center':
+        target.select();
+        target.cy().center(target);
+        break;
+      default:
+        break;
+    }
+
+    closeContextMenu();
+  };
+
+  const getTraversalTargets = (node: cytoscape.NodeSingular) => {
+    const parentEdge = node.incomers('edge[type = \"parent\"]').edges().first();
+    const parentNode = parentEdge && parentEdge.isEdge() ? parentEdge.source() : undefined;
+
+    const childEdge = node.outgoers('edge[type = \"parent\"]').edges().first();
+    const childNode = childEdge && childEdge.isEdge() ? childEdge.target() : undefined;
+
+    let prevSibling: cytoscape.NodeSingular | undefined;
+    let nextSibling: cytoscape.NodeSingular | undefined;
+
+    if (parentNode) {
+      const siblings = parentNode.outgoers('edge[type = \"parent\"]').targets();
+      const ids = siblings.map((sib: cytoscape.NodeSingular) => sib.id());
+      const index = ids.indexOf(node.id());
+      if (index > 0) {
+        prevSibling = siblings[index - 1];
+      }
+      if (index >= 0 && index + 1 < siblings.length) {
+        nextSibling = siblings[index + 1];
+      }
+    }
+
+    return { parentNode, childNode, prevSibling, nextSibling };
+  };
+
+  const focusNode = (node?: cytoscape.NodeSingular) => {
+    if (!node) return;
+    node.select();
+    node.cy().center(node);
+    const data = node.data();
+    onNodeSelect({
+      id: node.id(),
+      key: data.key,
+      type: data.type,
+      value: data.value,
+      position: node.position(),
+      parentId: data.parentId as string | undefined
+    });
+  };
+
+  const handleKeyboardNavigation = useCallback((event: KeyboardEvent) => {
+    if (!cyRef.current || !containerRef.current) return;
+
+    const cy = cyRef.current;
+    const nodes = cy.nodes();
+    if (!nodes || nodes.length === 0) return;
+
+    const selectedCollection = cy.$(':selected').nodes();
+    const selected: cytoscape.NodeSingular = selectedCollection.nonempty() ? selectedCollection[0] : nodes[0];
+
+    if (event.key === 'Tab') {
+      event.preventDefault();
+      const currentIndex = nodes.toArray().findIndex(node => node.id() === selected.id());
+      const nextIndex = event.shiftKey
+        ? (currentIndex - 1 + nodes.length) % nodes.length
+        : (currentIndex + 1) % nodes.length;
+      focusNode(nodes[nextIndex]);
+      return;
+    }
+
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      const data = selected.data();
+      onNodeEdit({
+        id: selected.id(),
+        key: data.key,
+        type: data.type,
+        value: data.value,
+        position: selected.position(),
+        parentId: data.parentId as string | undefined
+      });
+      return;
+    }
+
+    if (event.ctrlKey && ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key)) {
+      event.preventDefault();
+      const { parentNode, childNode, prevSibling, nextSibling } = getTraversalTargets(selected);
+      if (event.key === 'ArrowUp') {
+        focusNode(parentNode);
+      } else if (event.key === 'ArrowDown') {
+        focusNode(childNode);
+      } else if (event.key === 'ArrowLeft') {
+        focusNode(prevSibling);
+      } else if (event.key === 'ArrowRight') {
+        focusNode(nextSibling);
+      }
+    }
+  }, [onNodeEdit, onNodeSelect]);
 
   // Initialize Cytoscape
   useEffect(() => {
     if (containerRef.current && !cyRef.current) {
       cyRef.current = cytoscape({
         container: containerRef.current,
-        elements: convertToCytoscapeElements(),
+        elements: convertToCytoscapeElements,
         style: [
           {
             selector: 'node',
@@ -105,35 +293,110 @@ const GraphView: React.FC<GraphViewProps> = ({
             }
           }
         ],
-        layout: {
-          name: 'breadthfirst',
-          directed: true,
-          padding: 10,
-          spacingFactor: 1.5,
-          avoidOverlap: true,
-          nodeDimensionsIncludeLabels: true
+        layout: layoutOptions
+      });
+
+      const cyInstance = cyRef.current;
+
+      // Add event listeners
+      cyInstance.on('tap', 'node', (event) => {
+        const nodeId = event.target.id();
+        const data = event.target.data();
+        onNodeSelect({
+          id: nodeId,
+          key: data.key,
+          type: data.type,
+          value: data.value,
+          position: event.target.position(),
+          parentId: data.parentId as string | undefined
+        });
+      });
+
+      cyInstance.on('tap', (event) => {
+        if (event.target === cyInstance) {
+          cyInstance.elements().unselect();
+          closeContextMenu();
         }
       });
 
-      // Add event listeners
-      cyRef.current.on('tap', 'node', (event) => {
-        const nodeId = event.target.id();
-        onNodeSelect(nodeId);
+      cyInstance.on('dbltap', 'node', event => {
+        const data = event.target.data();
+        onNodeEdit({
+          id: event.target.id(),
+          key: data.key,
+          type: data.type,
+          value: data.value,
+          position: event.target.position(),
+          parentId: data.parentId as string | undefined
+        });
+      });
+
+      cyInstance.on('cxttap', 'node', event => {
+        event.preventDefault();
+        const { pageX, pageY } = event.originalEvent as MouseEvent;
+        setContextMenu({
+          x: pageX,
+          y: pageY,
+          targetId: event.target.id(),
+          parentId: event.target.data('parentId') as string | undefined
+        });
+      });
+
+      cyInstance.on('cxttap', event => {
+        if (event.target === cyInstance) {
+          closeContextMenu();
+        }
+      });
+
+      cyInstance.on('dragfree', 'node', event => {
+        const target = event.target;
+        const dropPosition = event.position || target.position();
+
+        const potentialParent = cyInstance.nodes().filter(node => {
+          if (node.id() === target.id()) return false;
+          const box = node.boundingBox();
+          return (
+            dropPosition.x >= box.x1 &&
+            dropPosition.x <= box.x2 &&
+            dropPosition.y >= box.y1 &&
+            dropPosition.y <= box.y2
+          );
+        }).first();
+
+        const newParentId = potentialParent && potentialParent.nonempty() ? potentialParent.id() : target.data('parentId');
+
+        if (newParentId) {
+          onNodeMove({
+            id: target.id(),
+            newParentId,
+            position: dropPosition
+          });
+        }
+      });
+
+      cyInstance.on('zoom pan', () => {
+        if (!onViewportChange) return;
+        onViewportChange({
+          zoom: cyInstance.zoom(),
+          pan: cyInstance.pan()
+        });
       });
     }
 
     // Update elements when graph changes
     if (cyRef.current) {
-      cyRef.current.elements().remove();
-      cyRef.current.add(convertToCytoscapeElements());
-      cyRef.current.layout({
-        name: 'breadthfirst',
-        directed: true,
-        padding: 10,
-        spacingFactor: 1.5,
-        avoidOverlap: true,
-        nodeDimensionsIncludeLabels: true
-      }).run();
+      const cy = cyRef.current;
+      cy.batch(() => {
+        cy.elements().remove();
+        cy.add(convertToCytoscapeElements);
+      });
+
+      const hasPositions = graph.nodes.every(node => !!node.position);
+      if (!hasPositions) {
+        const layout = cy.layout(layoutOptions);
+        cy.one('layoutstop', () => syncPositionsToParent());
+        layout.run();
+      }
     }
 
     return () => {
@@ -142,11 +405,52 @@ const GraphView: React.FC<GraphViewProps> = ({
         cyRef.current = null;
       }
     };
-  }, [graph]);
+  }, [convertToCytoscapeElements, graph, layoutOptions]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const listener = (event: KeyboardEvent) => handleKeyboardNavigation(event);
+    container.addEventListener('keydown', listener);
+    return () => container.removeEventListener('keydown', listener);
+  }, [handleKeyboardNavigation]);
 
   return (
-    <div className="graph-view" ref={containerRef} />
+    <div className="graph-view" ref={containerRef} tabIndex={0} style={{ outline: 'none', position: 'relative' }}>
+      {contextMenu && (
+        <div
+          className="graph-context-menu"
+          style={{
+            position: 'fixed',
+            top: contextMenu.y,
+            left: contextMenu.x,
+            background: '#2b2b2b',
+            color: '#fff',
+            borderRadius: 4,
+            boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
+            zIndex: 10,
+            minWidth: 160
+          }}
+        >
+          <button className="context-action" onClick={() => handleContextAction('edit')} style={menuButtonStyle}>Edit Node</button>
+          <button className="context-action" onClick={() => handleContextAction('add')} style={menuButtonStyle}>Add Child</button>
+          <button className="context-action" onClick={() => handleContextAction('delete')} style={menuButtonStyle}>Delete…</button>
+          <button className="context-action" onClick={() => handleContextAction('center')} style={menuButtonStyle}>Center on Node</button>
+        </div>
+      )}
+    </div>
   );
+};
+
+const menuButtonStyle: React.CSSProperties = {
+  display: 'block',
+  width: '100%',
+  padding: '8px 12px',
+  background: 'transparent',
+  border: 'none',
+  color: 'inherit',
+  textAlign: 'left',
+  cursor: 'pointer'
 };
 
 export default GraphView;

--- a/jsonic/src/utils/jsonParser.ts
+++ b/jsonic/src/utils/jsonParser.ts
@@ -252,10 +252,24 @@ export const moveNode = (
   newParentId: string,
   position?: { x: number; y: number }
 ): JsonGraph => {
-  const node = findNode(graph, nodeId);
-  const newParent = findNode(graph, newParentId);
+  const nodeMap = new Map<string, JsonNode>(graph.nodes.map(node => [node.id, node]));
+  const node = nodeMap.get(nodeId);
+  const newParent = nodeMap.get(newParentId);
 
   if (!node || !newParent) {
+    return graph;
+  }
+
+  const isDescendant = (currentId: string, searchId: string): boolean => {
+    const currentNode = nodeMap.get(currentId);
+    if (!currentNode?.children || currentNode.children.length === 0) {
+      return false;
+    }
+
+    return currentNode.children.some(childId => childId === searchId || isDescendant(childId, searchId));
+  };
+
+  if (nodeId === newParentId || isDescendant(nodeId, newParentId)) {
     return graph;
   }
 


### PR DESCRIPTION
## Summary
- add graph mutation helpers for adding, moving, and deleting nodes while keeping edges consistent
- extend the Cytoscape GraphView with structured edit/create/delete/move events, keyboard navigation, and context menu actions
- wire App callbacks to mutate the JSON graph, sync text view, and persist layout positions; document the updated architecture and checklist

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954877a96908323a49705098dac0afa)